### PR TITLE
Match delete before update in websafe resource options, fixes /resour…

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -866,13 +866,13 @@ class RouteCollection implements RouteCollectionInterface
 		// Web Safe?
 		if (isset($options['websafe']))
 		{
-			if (in_array('update', $methods))
-			{
-				$this->post($name . '/' . $id, $new_name . '::update/$1', $options);
-			}
 			if (in_array('delete', $methods))
 			{
 				$this->post($name . '/' . $id . '/delete', $new_name . '::delete/$1', $options);
+			}
+			if (in_array('update', $methods))
+			{
+				$this->post($name . '/' . $id, $new_name . '::update/$1', $options);
 			}
 		}
 


### PR DESCRIPTION
Discovered an issue where generated resource routes using the websafe option would route requests of POST /resource/(:segment)/delete to Controller::update/$1 instead of Controller::delete/$1.

From the routes documentation:

> The routes are matched in the order they are specified, so if you have a resource photos above a get ‘photos/poll’ the show action’s route for the resource line will be matched before the get line. To fix this, move the get line above the resource line so that it is matched first.

Because update was specified first, attempts to post to the delete route would match the update function instead.

Switching the order fixes the issue.